### PR TITLE
samba-folders: Update smb.gtpl to enable files app on iOS / iPads 18+

### DIFF
--- a/samba-folders/CHANGELOG.md
+++ b/samba-folders/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 12.3.3
+- Enable Samba configurations to improve interoperability with Apple devices
+
 ## 12.3.2
 
 - Suppress benign idmap logged error

--- a/samba-folders/config.yaml
+++ b/samba-folders/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 12.3.2
+version: 12.3.3
 slug: samba_folders
 name: Samba Folders
 description: Expose Home Assistant folders with SMB/CIFS

--- a/samba-folders/rootfs/usr/share/tempio/smb.gtpl
+++ b/samba-folders/rootfs/usr/share/tempio/smb.gtpl
@@ -25,3 +25,5 @@
    mangled names = no
    dos charset = CP850
    unix charset = UTF-8
+
+   vfs objects = catia fruit streams_xattr


### PR DESCRIPTION
* Update smb.gtpl to enables files.app on iOS / iPads s 18+

included `catia` and `fruit` per documentation on Samba and recommendation for further OSX interoperability